### PR TITLE
Added offset classes

### DIFF
--- a/css/scss/_grid.scss
+++ b/css/scss/_grid.scss
@@ -36,6 +36,13 @@
     @for $i from 1 through 12 {
         .span#{$i} {
             width: ($unit * $i) + ($margin * ($i - 1));
+            // remove float so span#'s don't stack inline.
+            &.break {
+                float:none;
+            }
+        }
+        .offset#{$i} {
+            margin-left: ($unit * $i) + ($margin * ($i +1));
         }
     }
 

--- a/example.html
+++ b/example.html
@@ -177,6 +177,41 @@
 		<div class="span12" style="background:pink;height:50px;margin-bottom:10px;">.span12</div>
 	</div>
 
+	<div class="group">
+		<div class="span11 offset1" style="background:pink;height:50px;margin-bottom:10px;">.span11 .offset1</div>
+		<div class="span10 offset2" style="background:pink;height:50px;margin-bottom:10px;">.span10 .offset2</div>
+
+		<div class="span9 offset3" style="background:pink;height:50px;margin-bottom:10px;">.span9 .offset3</div>
+		<div class="span8 offset4" style="background:pink;height:50px;margin-bottom:10px;">.span8 .offset4</div>
+		
+		<div class="span7 offset5" style="background:pink;height:50px;margin-bottom:10px;">.span7 .offset5</div>
+		<div class="span6 offset6" style="background:pink;height:50px;margin-bottom:10px;">.span6 .offset6</div>
+		<div class="span5 offset7" style="background:pink;height:50px;margin-bottom:10px;">.span5 .offset7</div>
+		<div class="span4 offset8" style="background:pink;height:50px;margin-bottom:10px;">.span4 .offset8</div>
+
+		<div class="span3 offset9" style="background:pink;height:50px;margin-bottom:10px;">.span3 .offset9</div>
+		<div class="span2 offset10" style="background:pink;height:50px;margin-bottom:10px;">.span2 .offset10</div>
+		<div class="span1 offset11" style="background:pink;height:50px;margin-bottom:10px;">.span1 .offset11</div>
+	</div>
+
+	<div class="group">
+		<div class="span1 break" style="background:pink;height:50px;margin-bottom:10px;">.span1.break</div>
+		<div class="span2 break" style="background:pink;height:50px;margin-bottom:10px;">.span2.break</div>
+
+		<div class="span3 break" style="background:pink;height:50px;margin-bottom:10px;">.span3.break</div>
+		<div class="span4 break" style="background:pink;height:50px;margin-bottom:10px;">.span4.break</div>
+		
+		<div class="span5 break" style="background:pink;height:50px;margin-bottom:10px;">.span5.break</div>
+		<div class="span6 break" style="background:pink;height:50px;margin-bottom:10px;">.span6.break</div>
+		<div class="span7 break" style="background:pink;height:50px;margin-bottom:10px;">.span7.break</div>
+		<div class="span8 break" style="background:pink;height:50px;margin-bottom:10px;">.span8.break</div>
+
+		<div class="span9 break" style="background:pink;height:50px;margin-bottom:10px;">.span9.break</div>
+		<div class="span10 break" style="background:pink;height:50px;margin-bottom:10px;">.span10.break</div>
+		<div class="span11 break" style="background:pink;height:50px;margin-bottom:10px;">.span11.break</div>
+		<div class="span12 break" style="background:pink;height:50px;margin-bottom:10px;">.span12.break</div>
+	</div>
+
 	<hr>
 
 	<h2>Images</h2>


### PR DESCRIPTION
- .offset{#} allows span left spacing without adding empty .span#'s

Added break class.
- w/ appended .break class floated spans won't stack inline. Allows span right spacing w/o adding empty .span#'s

(see example.html for implementation.)
